### PR TITLE
Removed comments and minifies inline JS in the html file during build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,9 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: 'src/index.html',
       minify: isProduction && {
-        collapseWhitespace: true
+        collapseWhitespace: true,
+        removeComments: true,
+        minifyJS: true,
       },
       inlineSource: isProduction && '\.(js|css)$'
     }),


### PR DESCRIPTION
This will save some extra bytes while still being able to document your code. Also good for when you need to add some inline js inside the index.html file to get it minified.